### PR TITLE
Fixed path for Build compatibility

### DIFF
--- a/firmware/examples/spark-plotly.ino
+++ b/firmware/examples/spark-plotly.ino
@@ -1,4 +1,4 @@
-#include "spark-plotly.h"
+#include "spark-plotly/spark-plotly.h"
 
 #define DATA_POINTS 4
 


### PR DESCRIPTION
Hi, Richard from Particle here. Was going through the top 100 libraries (congrats!) and noticed that there was an include path issue for Build and wrote a little fix. Please merge and reimport the library into Build.

Thanks!
